### PR TITLE
Remove reflection, use official APIs, add Print.ToStream method

### DIFF
--- a/src/VisualExtensions.cs
+++ b/src/VisualExtensions.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using Avalonia;
-using Avalonia.Collections;
 using Avalonia.Layout;
+using Avalonia.VisualTree;
 
 namespace AvaloniaUI.PrintToPDF
 {
@@ -33,16 +32,8 @@ namespace AvaloniaUI.PrintToPDF
         l.ApplyTemplate();
       if (root is T t)
         result.Add(t);
-      foreach (var child in GetVisualChildren(root))
+      foreach (var child in root.GetVisualChildren())
         FindAllVisuals(child, result);
     }
-    
-    static VisualExtensions()
-    {
-      var vcProperty = typeof(Visual).GetProperty("VisualChildren", BindingFlags.Instance | BindingFlags.NonPublic);
-      GetVisualChildren = root => (IAvaloniaList<Visual>) vcProperty!.GetValue(root);
-    }
-
-    public static readonly Func<Visual, IAvaloniaList<Visual>> GetVisualChildren;
   }
 }


### PR DESCRIPTION
Hi!

This PR:
1. Removes usage of internal APIs. With current target version there are all needed public API members.
2. Adds Print.ToStream method, as not everywhere sync access to file system is available (browser)